### PR TITLE
Snappier Azure Indexer shutdowns when Ctrl-C is used

### DIFF
--- a/AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer.Tests/IndexerTester.cs
+++ b/AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer.Tests/IndexerTester.cs
@@ -64,7 +64,7 @@ namespace Stratis.Bitcoin.Features.AzureIndexer.Tests
                 foreach (var table in _Importer.Configuration.EnumerateTables())
                 {
 					table.CreateIfNotExistsAsync().GetAwaiter().GetResult();
-                    var entities = table.ExecuteQueryAsync(new TableQuery()).GetAwaiter().GetResult().ToList();
+                    var entities = table.ExecuteQuery(new TableQuery()).ToList();
                     Parallel.ForEach(entities, e =>
                     {
                         table.ExecuteAsync(TableOperation.Delete(e)).GetAwaiter().GetResult();

--- a/AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer/AzureIndexerLoop.cs
+++ b/AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer/AzureIndexerLoop.cs
@@ -226,7 +226,7 @@ namespace Stratis.Bitcoin.Features.AzureIndexer
         {
             this.logger.LogTrace("()");
 
-            while (!cancellationToken.IsCancellationRequested)
+            while (this.StoreTip.Height < indexerSettings.To && !cancellationToken.IsCancellationRequested)
             {
                 try
                 {

--- a/AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer/AzureIndexerLoop.cs
+++ b/AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer/AzureIndexerLoop.cs
@@ -200,10 +200,7 @@ namespace Stratis.Bitcoin.Features.AzureIndexer
             {
                 try
                 {                  
-                    if (!cancellationToken.IsCancellationRequested)
-                    {
-                        this.AzureIndexer.IndexChain(this.Chain, cancellationToken);
-                    }
+                    this.AzureIndexer.IndexChain(this.Chain, cancellationToken);
                 }
                 catch (OperationCanceledException)
                 {

--- a/AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer/AzureIndexerLoop.cs
+++ b/AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer/AzureIndexerLoop.cs
@@ -201,6 +201,7 @@ namespace Stratis.Bitcoin.Features.AzureIndexer
                 try
                 {                  
                     this.AzureIndexer.IndexChain(this.Chain, cancellationToken);
+                    await Task.Delay(TimeSpan.FromMinutes(1), cancellationToken).ContinueWith(t => { }).ConfigureAwait(false);
                 }
                 catch (OperationCanceledException)
                 {

--- a/AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer/AzureIndexerLoop.cs
+++ b/AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer/AzureIndexerLoop.cs
@@ -47,7 +47,10 @@ namespace Stratis.Bitcoin.Features.AzureIndexer
         /// <summary>The highest block that has been indexed.</summary>
         internal ChainedBlock StoreTip { get; private set; }
 
+        /// <summary>The Azure Indexer.</summary>
         public AzureIndexer AzureIndexer { get; private set; }
+
+        /// <summary>The Indexer Configuration.</summary>
         public IndexerConfiguration IndexerConfig { get; private set; }
         
         /// <summary>

--- a/AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer/AzureIndexerLoop.cs
+++ b/AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer/AzureIndexerLoop.cs
@@ -205,9 +205,14 @@ namespace Stratis.Bitcoin.Features.AzureIndexer
                         this.AzureIndexer.IndexChain(this.Chain, cancellationToken);
                     }
                 }
-                catch (Exception)
+                catch (OperationCanceledException)
                 {
-                    // Try again 1 minute later
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    // If something goes wrong then try again 1 minute later
+                    IndexerTrace.ErrorWhileImportingBlockToAzure(this.StoreTip.HashBlock, ex);
                     await Task.Delay(TimeSpan.FromMinutes(1), cancellationToken).ContinueWith(t => { }).ConfigureAwait(false);
                 }
             }
@@ -274,6 +279,10 @@ namespace Stratis.Bitcoin.Features.AzureIndexer
 
                     // Update the StoreTip value from the minHeight
                     this.SetStoreTip(this.Chain.GetBlock(Math.Min(minHeight, this.indexerSettings.To)));
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
                 }
                 catch (Exception ex)
                 {

--- a/AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer.csproj
+++ b/AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer.csproj
@@ -25,9 +25,9 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="NStratis" Version="4.0.0.33" />
-    <PackageReference Include="Stratis.Bitcoin" Version="1.0.3-alpha" />
-    <PackageReference Include="Stratis.Bitcoin.Features.BlockStore" Version="1.0.3-alpha" />
-    <PackageReference Include="Stratis.Bitcoin.Features.Consensus" Version="1.0.3-alpha" />
+    <PackageReference Include="Stratis.Bitcoin" Version="1.0.4-alpha" />
+    <PackageReference Include="Stratis.Bitcoin.Features.BlockStore" Version="1.0.4-alpha" />
+    <PackageReference Include="Stratis.Bitcoin.Features.Consensus" Version="1.0.4-alpha" />
     <PackageReference Include="WindowsAzure.Storage" Version="8.5.0" />
   </ItemGroup>
 

--- a/AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer.csproj
+++ b/AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer.csproj
@@ -25,8 +25,9 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="NStratis" Version="4.0.0.33" />
-    <PackageReference Include="Stratis.Bitcoin" Version="1.0.2-alpha" />
-    <PackageReference Include="Stratis.Bitcoin.Features.BlockStore" Version="1.0.2-alpha" />
+    <PackageReference Include="Stratis.Bitcoin" Version="1.0.3-alpha" />
+    <PackageReference Include="Stratis.Bitcoin.Features.BlockStore" Version="1.0.3-alpha" />
+    <PackageReference Include="Stratis.Bitcoin.Features.Consensus" Version="1.0.3-alpha" />
     <PackageReference Include="WindowsAzure.Storage" Version="8.5.0" />
   </ItemGroup>
 

--- a/AzureIndexer/Stratis.IndexerD/Stratis.IndexerD.csproj
+++ b/AzureIndexer/Stratis.IndexerD/Stratis.IndexerD.csproj
@@ -20,11 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.0.0" />
     <PackageReference Include="NLog" Version="5.0.0-beta09" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="1.0.0-rtm-beta5" />
-    <PackageReference Include="NStratis" Version="4.0.0.33" />
-    <PackageReference Include="Stratis.Bitcoin" Version="1.0.2-alpha" />
-    <PackageReference Include="Stratis.Bitcoin.Features.BlockStore" Version="1.0.2-alpha" />
-    <PackageReference Include="Stratis.Bitcoin.Features.Consensus" Version="1.0.2-alpha" />	
+    <PackageReference Include="NLog.Extensions.Logging" Version="1.0.0-rtm-beta5" />	
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR:

- adds CancellationToken parameters to key methods to achieve quicker shutdowns.
- catches OperationCancelledExceptions to pre-empt delays and break out of the loops sooner.
- updates package references.
- respects the "To" value in the indexing loop.
- optimizes IndexChainAsync and ExecuteQueryAsync.