### PR TITLE
Improve error handling to detect blocks missing from block store

### DIFF
--- a/AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer/AzureIndexerLoop.cs
+++ b/AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer/AzureIndexerLoop.cs
@@ -288,8 +288,9 @@ namespace Stratis.Bitcoin.Features.AzureIndexer
                 catch (Exception ex)
                 {
                     // If something goes wrong then try again 1 minute later
+                    this.logger.LogError(ex.Message);
                     IndexerTrace.ErrorWhileImportingBlockToAzure(this.StoreTip.HashBlock, ex);
-                    await Task.Delay(TimeSpan.FromMinutes(1), cancellationToken).ContinueWith(t => { }).ConfigureAwait(false);
+                    await Task.Delay(TimeSpan.FromSeconds(10), cancellationToken).ContinueWith(t => { }).ConfigureAwait(false);
                 }
             }
 

--- a/AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer/IBlocksRepository.cs
+++ b/AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer/IBlocksRepository.cs
@@ -6,6 +6,7 @@ namespace Stratis.Bitcoin.Features.AzureIndexer.IndexTasks
 {
     public interface IBlocksRepository
     {
+        Block GetStoreTip();
         IEnumerable<Block> GetBlocks(IEnumerable<uint256> hashes, CancellationToken cancellationToken);
     }
 
@@ -21,6 +22,11 @@ namespace Stratis.Bitcoin.Features.AzureIndexer.IndexTasks
         }
 
         #region IBlocksRepository Members
+
+        public Block GetStoreTip()
+        {
+            return _Repo.GetAsync(_Repo.BlockHash).GetAwaiter().GetResult();
+        }
 
         public IEnumerable<Block> GetBlocks(IEnumerable<uint256> hashes, CancellationToken cancellationToken)
         {


### PR DESCRIPTION
This PR improves error handling to detect the scenario where the chain and blocks stored in the DBreeze block repository are mutually inconsistent. More specifically, the scenario where blocks are missing from the block index but have been recorded in the chain.