### PR TITLE
Fix failing AzureIndexer tests cases

### DIFF
--- a/AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer.Tests/IndexerTester.cs
+++ b/AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer.Tests/IndexerTester.cs
@@ -38,6 +38,8 @@ namespace Stratis.Bitcoin.Features.AzureIndexer.Tests
             var config = AzureIndexerLoop.IndexerConfigFromSettings(
                 new AzureIndexerSettings() { StorageNamespace = folder }, Network.TestNet);
 
+            config.EnsureSetup();
+
             _Importer = config.CreateIndexer();
 
 			List<Task> creating = new List<Task>();
@@ -48,7 +50,7 @@ namespace Stratis.Bitcoin.Features.AzureIndexer.Tests
 
 			creating.Add(config.GetBlocksContainer().CreateIfNotExistsAsync());
 			Task.WaitAll(creating.ToArray());
-            config.EnsureSetup();
+
             _Folder = folder;
         }
 


### PR DESCRIPTION
This PR fixes:

"Message: System.Exception : The Azure Storage Emulator is not available or is not started"

in the Azure Indexer test cases that depend on the emulator.

Following this PR all test cases pass.