### PR TITLE
Align Azure Indexer with latest package versions (which include fix for issue 1176)

### DIFF
--- a/AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer/IndexerConfiguration.cs
+++ b/AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer/IndexerConfiguration.cs
@@ -143,16 +143,7 @@ namespace Stratis.Bitcoin.Features.AzureIndexer
         {
             return new AzureIndexer(this);
         }
-        /*
-        public NetworkPeer ConnectToNode(bool isRelay)
-        {
-            if (String.IsNullOrEmpty(Node))
-                throw new IndexerConfigurationErrorsException("Node setting is not configured");
 
-            NetworkPeerFactory networkPeerFactory = new NetworkPeerFactory(Network.StratisTest, DateTimeProvider.Default, new LoggerFactory(), new PayloadProvider().DiscoverPayloads());
-            return (NetworkPeer)networkPeerFactory.CreateConnectedNetworkPeerAsync(Node, ProtocolVersion.PROTOCOL_VERSION, isRelay: isRelay).Result;
-        }
-        */
         public IndexerClient CreateIndexerClient()
         {
             return new IndexerClient(this);

--- a/AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer/IndexerConfiguration.cs
+++ b/AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer/IndexerConfiguration.cs
@@ -143,7 +143,7 @@ namespace Stratis.Bitcoin.Features.AzureIndexer
         {
             return new AzureIndexer(this);
         }
-
+        /*
         public NetworkPeer ConnectToNode(bool isRelay)
         {
             if (String.IsNullOrEmpty(Node))
@@ -152,7 +152,7 @@ namespace Stratis.Bitcoin.Features.AzureIndexer
             NetworkPeerFactory networkPeerFactory = new NetworkPeerFactory(Network.StratisTest, DateTimeProvider.Default, new LoggerFactory(), new PayloadProvider().DiscoverPayloads());
             return (NetworkPeer)networkPeerFactory.CreateConnectedNetworkPeerAsync(Node, ProtocolVersion.PROTOCOL_VERSION, isRelay: isRelay).Result;
         }
-
+        */
         public IndexerClient CreateIndexerClient()
         {
             return new IndexerClient(this);

--- a/AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer.csproj
+++ b/AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer.csproj
@@ -24,9 +24,9 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
-    <PackageReference Include="Stratis.Bitcoin" Version="1.0.10-alpha" />
-    <PackageReference Include="Stratis.Bitcoin.Features.BlockStore" Version="1.0.10-alpha" />
-    <PackageReference Include="Stratis.Bitcoin.Features.Consensus" Version="1.0.10-alpha" />
+    <PackageReference Include="Stratis.Bitcoin" Version="1.0.11-alpha" />
+    <PackageReference Include="Stratis.Bitcoin.Features.BlockStore" Version="1.0.11-alpha" />
+    <PackageReference Include="Stratis.Bitcoin.Features.Consensus" Version="1.0.11-alpha" />
     <PackageReference Include="WindowsAzure.Storage" Version="8.7.0" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR upgrades the Stratis.Bitcoin packages used by the AzureIndexer to include the fix for issue 1176.

https://github.com/stratisproject/StratisBitcoinFullNode/issues/1176
