### PR TITLE
Upgraded nugets to 3.0.2. but not Sidechain packages as they are not …

### DIFF
--- a/AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer/IndexerClient.cs
+++ b/AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer/IndexerClient.cs
@@ -45,7 +45,7 @@ namespace Stratis.Bitcoin.Features.AzureIndexer
                 container.GetPageBlobReference(blockId.ToString()).DownloadToStreamAsync(ms).GetAwaiter().GetResult();
                 ms.Position = 0;
                 Block b = this.network.Consensus.ConsensusFactory.CreateBlock();
-                BitcoinStream stream = new BitcoinStream(ms.ToArray());
+                BitcoinStream stream = new BitcoinStream(ms, true);
                 stream.ConsensusFactory = this.network.Consensus.ConsensusFactory;
                 b.ReadWrite(stream);
                 return b;

--- a/AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer.csproj
+++ b/AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer/Stratis.Bitcoin.Features.AzureIndexer.csproj
@@ -26,11 +26,11 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
     <PackageReference Include="NLog" Version="5.0.0-beta09" />
-    <PackageReference Include="Stratis.Bitcoin" Version="3.0.0.4-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Features.BlockStore" Version="3.0.0.4-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Features.Consensus" Version="3.0.0.4-beta" />
+    <PackageReference Include="Stratis.Bitcoin" Version="3.0.2" />
+    <PackageReference Include="Stratis.Bitcoin.Features.BlockStore" Version="3.0.2" />
+    <PackageReference Include="Stratis.Bitcoin.Features.Consensus" Version="3.0.2" />
     <PackageReference Include="Stratis.Bitcoin.Features.SmartContracts" Version="0.0.6-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Networks" Version="3.0.0.4-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Networks" Version="3.0.2" />
     <PackageReference Include="Stratis.FodyNlogAdapter" Version="3.0.0.4-beta" />
     <PackageReference Include="Stratis.SmartContracts.CLR" Version="0.0.6-beta" />
     <PackageReference Include="WindowsAzure.Storage" Version="8.7.0" />

--- a/AzureIndexer/Stratis.IndexerD/Stratis.IndexerD.csproj
+++ b/AzureIndexer/Stratis.IndexerD/Stratis.IndexerD.csproj
@@ -20,13 +20,13 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
     <PackageReference Include="NLog" Version="5.0.0-beta09" />
-    <PackageReference Include="Stratis.Bitcoin" Version="3.0.0.4-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Api" Version="3.0.0.4-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Features.BlockStore" Version="3.0.0.4-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Features.Consensus" Version="3.0.0.4-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Features.PoA" Version="3.0.0.4-beta" />
+    <PackageReference Include="Stratis.Bitcoin" Version="3.0.2" />
+    <PackageReference Include="Stratis.Bitcoin.Api" Version="3.0.2" />
+    <PackageReference Include="Stratis.Bitcoin.Features.BlockStore" Version="3.0.2" />
+    <PackageReference Include="Stratis.Bitcoin.Features.Consensus" Version="3.0.2" />
+    <PackageReference Include="Stratis.Bitcoin.Features.PoA" Version="3.0.2" />
     <PackageReference Include="Stratis.Bitcoin.Features.SmartContracts" Version="0.0.6-beta" />
-    <PackageReference Include="Stratis.Bitcoin.Features.Wallet" Version="3.0.0.4-beta" />
+    <PackageReference Include="Stratis.Bitcoin.Features.Wallet" Version="3.0.2" />
     <PackageReference Include="Stratis.FodyNlogAdapter" Version="3.0.0.4-beta" />
     <PackageReference Include="Stratis.SmartContracts.CLR.Validation" Version="0.0.3-beta" />
     <PackageReference Include="Stratis.SmartContracts.RuntimeObserver" Version="0.0.2-beta" />


### PR DESCRIPTION
Upgraded all Stratis.Bitcoin packages except for SideChain because of that, Indexer works just for StratisMain or StratisTestnet networks.

Cirrus(sidechain) network not supported yet